### PR TITLE
Replace `BlockCode` from elements with simple `pre`

### DIFF
--- a/packages/app-exports/src/components/Details/ExportDetails.tsx
+++ b/packages/app-exports/src/components/Details/ExportDetails.tsx
@@ -1,8 +1,4 @@
-import {
-  ListDetailsItem,
-  ListDetails,
-  BlockCode
-} from '@commercelayer/app-elements'
+import { ListDetailsItem, ListDetails } from '@commercelayer/app-elements'
 import { useExportDetailsContext } from './Provider'
 import { StatusBadge } from './StatusBadge'
 
@@ -29,12 +25,24 @@ export function ExportDetails(): JSX.Element | null {
       ) : null}
 
       <ListDetailsItem label='Filters'>
-        {data.filters != null ? <BlockCode json={data.filters} /> : '-'}
+        <JsonPreview json={data.filters} />
       </ListDetailsItem>
       <ListDetailsItem label='Dry Data'>
         {data.dry_data === true ? 'true' : 'false'}
       </ListDetailsItem>
       <ListDetailsItem label='Format'>{data.format}</ListDetailsItem>
     </ListDetails>
+  )
+}
+
+function JsonPreview({ json }: { json?: object | null }): JSX.Element {
+  return (
+    <pre>
+      {json != null && Object.keys(json).length > 0 ? (
+        <>{JSON.stringify(json, null, 2)}</>
+      ) : (
+        <>-</>
+      )}
+    </pre>
   )
 }


### PR DESCRIPTION
## What I did

`<BlockCode>` component will no longer exist in app-elements.
We can safely replace it with a simple `<pre>` tag.

<img width="594" alt="image" src="https://github.com/commercelayer/app-exports/assets/30926550/a8ff0034-daa2-43e4-a7cc-59d10a93be46">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
