### PR TITLE
Add `tags` to the include options for taggable resources

### DIFF
--- a/packages/app/src/data/relationships.test.ts
+++ b/packages/app/src/data/relationships.test.ts
@@ -8,7 +8,8 @@ describe('getRelationshipsByResourceType', () => {
   test('Should retrieve a list of relationships', () => {
     expect(getRelationshipsByResourceType('bundles')).toMatchObject([
       'sku_list',
-      'sku_list_items'
+      'sku_list_items',
+      'tags'
     ])
   })
 

--- a/packages/app/src/data/relationships.ts
+++ b/packages/app/src/data/relationships.ts
@@ -1,9 +1,9 @@
 import { type ResourceWithRelationship } from 'App'
 
 export const exportRelationships: Record<ResourceWithRelationship, string[]> = {
-  bundles: ['sku_list', 'sku_list_items'],
+  bundles: ['sku_list', 'sku_list_items', 'tags'],
   customer_subscriptions: ['customer'],
-  customers: ['customer_subscriptions'],
+  customers: ['customer_subscriptions', 'tags'],
   orders: [
     'customer',
     'shipping_address',
@@ -17,7 +17,8 @@ export const exportRelationships: Record<ResourceWithRelationship, string[]> = {
     'captures',
     'voids',
     'refunds',
-    'transactions'
+    'transactions',
+    'tags'
   ],
   order_subscriptions: [
     'customer',
@@ -27,7 +28,7 @@ export const exportRelationships: Record<ResourceWithRelationship, string[]> = {
   ],
   payment_methods: ['order'],
   prices: ['sku', 'price_tiers'],
-  shipments: ['order', 'shipping_category', 'shipping_method'],
+  shipments: ['order', 'shipping_category', 'shipping_method', 'tags'],
   shipping_categories: ['skus'],
   shipping_methods: ['shipments'],
   skus: [
@@ -35,7 +36,8 @@ export const exportRelationships: Record<ResourceWithRelationship, string[]> = {
     'prices',
     'prices.price_tiers',
     'stock_items',
-    'tax_categories'
+    'tax_categories',
+    'tags'
   ],
   sku_lists: ['sku_list_items', 'bundles'],
   sku_list_items: ['sku'],


### PR DESCRIPTION
## What I did

I've added the opportunity to include `tags` in the exported resources.

<img width="680" alt="image" src="https://github.com/commercelayer/app-exports/assets/30926550/8c953bc6-5f76-41c6-ba4f-a58e1a8b094d">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
